### PR TITLE
Calc std of emsd using frequency weights

### DIFF
--- a/trackpy/motion.py
+++ b/trackpy/motion.py
@@ -190,7 +190,7 @@ def imsd(traj, mpp, fps, max_lagtime=100, statistic='msd', pos_columns=None):
 
 
 def emsd(traj, mpp, fps, max_lagtime=100, detail=False,
-        bessel_correction = True, pos_columns=None):
+        bessel_correction=True, pos_columns=None):
     """Compute the ensemble mean squared displacements of many particles.
 
     Parameters
@@ -209,6 +209,8 @@ def emsd(traj, mpp, fps, max_lagtime=100, detail=False,
         bessel_correction to True if you want to apply
         Bessel's Correction to the calculation of the
         standard deviation.
+    pos_columns : If None, pos_columns will be set to 
+        ['x','y'].
 
     Returns
     -------
@@ -247,7 +249,10 @@ def emsd(traj, mpp, fps, max_lagtime=100, detail=False,
         variance = np.Inf
     else:
         variance = numerator.div(denominator, axis=0)
+
+    # Warning: the following assumes pos_columns is ['x','y'] 
     variance = variance[['<x>', '<y>', '<x^2>','<y^2>','msd']]
+
     std = np.sqrt(variance)
     std.columns = 'std_' + std.columns
 

--- a/trackpy/motion.py
+++ b/trackpy/motion.py
@@ -202,15 +202,17 @@ def emsd(traj, mpp, fps, max_lagtime=100, detail=False,
     max_lagtime : intervals of frames out to which MSD is computed
         Default: 100
     detail : Set to True to include <x>, <y>, <x^2>, <y^2>,
-        and their biased weighted standard deviations in the
-        mean, std_<x>, std_<y>, std_<x^2>, std_<y^2>.
-        Returns only <r^2> by default.
+        N, and their biased weighted standard deviations in
+        the mean, std_<x>, std_<y>, std_<x^2>, std_<y^2>,
+        and std_msd.  Returns only <r^2> by default. If
+        pandas is out-of-date, the std columns may not be
+        calculated.
     bessel_correction : If detail is True, set
         bessel_correction to True if you want to apply
         Bessel's Correction to the calculation of the
         standard deviation.
-    pos_columns : If None, pos_columns will be set to 
-        ['x','y'].
+    pos_columns : The names of the pos_columns in traj. If
+        None, pos_columns will be set to ['x','y'].
 
     Returns
     -------

--- a/trackpy/motion.py
+++ b/trackpy/motion.py
@@ -247,8 +247,8 @@ def emsd(traj, mpp, fps, max_lagtime=100, detail=False,
         # will still be biased, just less so than otherwise.
     variance = numerator.div(denominator, axis=0)
 
-    # Warning: the following assumes pos_columns is ['x','y'] 
-    variance = variance[['<x>', '<y>', '<x^2>','<y^2>','msd']]
+    # Just keep the first few columns.
+    variance = variance.loc[:,variance.columns[0]:'msd']
 
     std = np.sqrt(variance)
     std.columns = 'std_' + std.columns

--- a/trackpy/motion.py
+++ b/trackpy/motion.py
@@ -259,7 +259,9 @@ def emsd(traj, mpp, fps, max_lagtime=100, detail=False,
         return results.join(std).set_index('lagt')
 
     except TypeError:
-        # This error may arise if pandas is out of date.
+        # This error may arise if pandas is out of date:
+        #     Pandas 0.13.1 throws a TypeError.
+        #     Pandas 0.14.1 does not.
         return results.set_index('lagt')
 
 

--- a/trackpy/motion.py
+++ b/trackpy/motion.py
@@ -245,10 +245,7 @@ def emsd(traj, mpp, fps, max_lagtime=100, detail=False,
         # Bessel's correction makes it possible to calculate
         # the unbiased variance, but the standard deviation
         # will still be biased, just less so than otherwise.
-    if denominator <= 0:
-        variance = np.Inf
-    else:
-        variance = numerator.div(denominator, axis=0)
+    variance = numerator.div(denominator, axis=0)
 
     # Warning: the following assumes pos_columns is ['x','y'] 
     variance = variance[['<x>', '<y>', '<x^2>','<y^2>','msd']]

--- a/trackpy/motion.py
+++ b/trackpy/motion.py
@@ -248,7 +248,7 @@ def emsd(traj, mpp, fps, max_lagtime=100, detail=False,
     variance = numerator.div(denominator, axis=0)
 
     # Just keep the first few columns.
-    variance = variance.loc[:,variance.columns[0]:'msd']
+    variance = variance.loc[:,:'msd']
 
     std = np.sqrt(variance)
     std.columns = 'std_' + std.columns

--- a/trackpy/motion.py
+++ b/trackpy/motion.py
@@ -189,8 +189,7 @@ def imsd(traj, mpp, fps, max_lagtime=100, statistic='msd', pos_columns=None):
     return results
 
 
-def emsd(traj, mpp, fps, max_lagtime=100, detail=False,
-        bessel_correction=True, pos_columns=None):
+def emsd(traj, mpp, fps, max_lagtime=100, detail=False, pos_columns=None):
     """Compute the ensemble mean squared displacements of many particles.
 
     Parameters
@@ -207,10 +206,6 @@ def emsd(traj, mpp, fps, max_lagtime=100, detail=False,
         and std_msd.  Returns only <r^2> by default. If
         pandas is out-of-date, the std columns may not be
         calculated.
-    bessel_correction : If detail is True, set
-        bessel_correction to True if you want to apply
-        Bessel's Correction to the calculation of the
-        standard deviation.
     pos_columns : The names of the pos_columns in traj. If
         None, pos_columns will be set to ['x','y'].
 
@@ -243,16 +238,9 @@ def emsd(traj, mpp, fps, max_lagtime=100, detail=False,
         # Calculation of biased weighted standard deviation
         numerator = ((msds.subtract(results))**2).mul(msds['N'], axis=0).sum(level=1)
         denominator = msds['N'].sum(level=1)
-        if bessel_correction:
-            denominator -= 1
-            # Bessel's correction makes it possible to calculate
-            # the unbiased variance, but the standard deviation
-            # will still be biased, just less so than otherwise.
+        denominator -= 1    # Bessel's correction
         variance = numerator.div(denominator, axis=0)
-    
-        # Just keep the first few columns.
         variance = variance.loc[:,:'msd']
-    
         std = np.sqrt(variance)
         std.columns = 'std_' + std.columns
     

--- a/trackpy/motion.py
+++ b/trackpy/motion.py
@@ -211,7 +211,7 @@ def emsd(traj, mpp, fps, max_lagtime=100, detail=False, pos_columns=None):
     DataFrame([<x>, <y>, <x^2>, <y^2>, msd, N, lagt,
                std_<x>, std_<y>, std_<x^2>, std_<y^2>, 
                std_msd],
-              index=frame)
+              index=lagt)
 
     Notes
     -----
@@ -238,7 +238,7 @@ def emsd(traj, mpp, fps, max_lagtime=100, detail=False, pos_columns=None):
     std = np.sqrt(variance)
     std.columns = 'std_' + std.columns
 
-    return results.join(std)
+    return results.join(std).set_index('lagt')
 
 
 def compute_drift(traj, smoothing=0, pos_columns=None):

--- a/trackpy/tests/test_motion.py
+++ b/trackpy/tests/test_motion.py
@@ -185,6 +185,18 @@ class TestMSD(unittest.TestCase):
         actual.index = expected.index
         assert_series_equal(np.round(actual), expected)
 
+    def test_detail(self):
+        EARLY = 7 # only early lag times have good stats
+        no_detail = tp.emsd(self.many_walks, 1, 1,
+                max_lagtime=EARLY, detail=False)
+        with_detail = tp.emsd(self.many_walks, 1, 1,
+                max_lagtime=EARLY, detail=True)
+        # HACK: Float64Index imprecision ruins index equality.
+        # Test them separately. If that works, make them exactly the same.
+        assert_almost_equal(no_detail.values,with_detail.msd.values)
+        with_detail.index = no_detail.index
+        assert_series_equal(no_detail,with_detail.msd)
+
 
 class TestSpecial(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
BUG: Catch an error that Pandas 0.13.1 throws.
TST: Test the emsd() function when detail=True.
MAINT: emsd(detail=True) returns a DataFrame with index=lagt 
